### PR TITLE
Changed go.mod Module

### DIFF
--- a/cmd/catchpoint-exporter/main.go
+++ b/cmd/catchpoint-exporter/main.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"catchpoint-prometheus-exporter/collector"
+	"github.com/grafana/catchpoint-prometheus-exporter/collector"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/go-kit/log/level"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module catchpoint-prometheus-exporter
+module github.com/grafana/catchpoint-prometheus-exporter
 
 go 1.20
 


### PR DESCRIPTION
Changed to go.mod Module name to be consistent with all other exporters. This allows the exporter to be imported in grafana agent.