### PR TITLE
Feat: Add some basic GH actions workflows to keep builds functional

### DIFF
--- a/.github/workflows/build-exporter.yml
+++ b/.github/workflows/build-exporter.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         with:
-          go-version: "1.23"
+          go-version-file: 'go.mod'
 
       - name: Download Go modules
         run: go mod download

--- a/.github/workflows/build-exporter.yml
+++ b/.github/workflows/build-exporter.yml
@@ -1,0 +1,70 @@
+name: Build Exporter
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  detect-changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      backend-changed: ${{ steps.changes.outputs.backend_any_changed == 'true' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect changed files
+        id: changes
+        uses: step-security/changed-files@2e07db73e5ccdb319b9a6c7766bd46d39d304bad # v47.0.5
+        with:
+          files_yaml: |
+            backend:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+              - 'Makefile.common'
+              - '.promu.yml'
+              - '.golangci.yml'
+
+  setup:
+    name: Setup
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.backend-changed == 'true'
+    uses: ./.github/workflows/setup.yml
+
+  build:
+    name: Build and test Go exporter
+    needs: [setup]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
+        with:
+          go-version: "1.23"
+
+      - name: Download Go modules
+        run: go mod download
+
+      - name: Build
+        run: make build
+
+      - name: Test
+        run: make test

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -1,0 +1,35 @@
+name: Setup
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  setup:
+    name: Setup tools and cache dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
+        with:
+          go-version: "1.23"
+
+      - name: Download Go modules
+        run: go mod download
+
+      - name: Tools cache
+        if: inputs.install-ci-deps
+        id: tools-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/go/bin
+          key: ${{ runner.os }}-tools-${{ hashFiles('Makefile') }}
+

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         with:
-          go-version: "1.23"
+          go-version-file: 'go.mod'
 
       - name: Download Go modules
         run: go mod download

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,9 @@
 BINARY       := catchpoint-exporter
-MODULE       := github.com/grafana/catchpoint-prometheus-exporter
 MAIN         := ./cmd/catchpoint-exporter
-DOCKER_IMAGE := catchpoint-prometheus-exporter
 
 GO     := go
 GOTEST := $(GO) test
 
-VERSION    ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
-COMMIT     ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 
 .PHONY: all build test lint fmt vet golangci-lint clean

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build:
 	$(GO) build  -o $(BINARY) $(MAIN)
 
 test:
-	$(GOTEST) ./...
+	$(GOTEST) ./... -v
 
 lint: fmt vet golangci-lint
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+BINARY       := catchpoint-exporter
+MODULE       := github.com/grafana/catchpoint-prometheus-exporter
+MAIN         := ./cmd/catchpoint-exporter
+DOCKER_IMAGE := catchpoint-prometheus-exporter
+
+GO     := go
+GOTEST := $(GO) test
+
+VERSION    ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT     ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+
+.PHONY: all build test lint fmt vet golangci-lint clean
+
+all: test build
+
+build:
+	$(GO) build  -o $(BINARY) $(MAIN)
+
+test:
+	$(GOTEST) ./...
+
+lint: fmt vet golangci-lint
+
+golangci-lint:
+	golangci-lint run ./...
+
+fmt:
+	$(GO) fmt ./...
+
+vet:
+	$(GO) vet ./...
+
+clean:
+	rm -f $(BINARY)

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -548,14 +548,14 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	ch <- c.up
 	if c.latestResponse == nil {
 		if c.cfg.VerboseLogging {
-			c.logger.Warn("msg", "No data available to collect")
+			c.logger.Warn("No data available to collect")
 		}
 		return
 	}
 
 	resp := c.latestResponse
 	if c.cfg.VerboseLogging {
-		c.logger.Debug("msg", "Collecting metrics", "responseID", resp.TestDetails.TestId)
+		c.logger.Debug("Collecting metrics", "responseID", resp.TestDetails.TestId)
 	}
 
 	labels := []string{


### PR DESCRIPTION
# What is this PR and why do we need it

This PR introduces a basic additional GH Actions workflow to validate the building of the exporter binary.
Only runs on changes to the golang codebase, and will *not* produce a built artefact for release. This is purely as a sanity check to ensure it builds and passes its tests.

In addition, this PR introduces:
- A basic makefile
- Couple fixes to log calls that had too many parameters and failed testing